### PR TITLE
chore: copy config.json before runing tests

### DIFF
--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -7,6 +7,7 @@
   "bugs": "https://github.com/syndesisio/syndesis/issues",
   "scripts": {
     "copy:assets": "yarn ncp node_modules/@atlasmap/atlasmap-data-mapper/src/assets/dm src/assets/dm",
+    "copy:exampleconfig": "cp src/config.json.example src/config.json",
     "format": "yarn prettier --no-color --single-quote --trailing-comma none --write \"./src/**/*.{ts,css,scss,js,json}\"",
     "generate": "node ./scripts/generate-ts.js",
     "license": "license-reporter save --xml licenses.xml",

--- a/app/ui/pom.xml
+++ b/app/ui/pom.xml
@@ -104,6 +104,15 @@
             </configuration>
           </execution>
           <execution>
+            <id>yarn copy:exampleconfig</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>copy:exampleconfig</arguments>
+            </configuration>
+          </execution>
+          <execution>
             <id>yarn ng test</id>
             <goals>
               <goal>yarn</goal>


### PR DESCRIPTION
A workaround for `ENOENT: no such file or directory, stat '/workspace/app/ui/src/config.json'`, but then I got another weird test error
```
HeadlessChrome 67.0.3391 (Linux 0.0.0) ERROR
  An error was thrown in afterAll
  [object ErrorEvent] thrown
HeadlessChrome 67.0.3391 (Linux 0.0.0) ERROR
  An error was thrown in afterAll
  [object ErrorEvent] thrown

Finished in 2.955 secs / 2.928 secs @ 16:06:37 GMT-0400 (EDT)

SUMMARY:
✔ 72 tests completed
ℹ 4 tests skipped
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```